### PR TITLE
Re-enable GitHub actions after 60 days of inactivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,4 @@
 Centralized dispatching for GitHub Actions 
 
 [![PangeoDaskUpdater](https://github.com/pangeo-bot/dispatcher/actions/workflows/watch-pangeo-dask-feedstock.yml/badge.svg)](https://github.com/pangeo-bot/dispatcher/actions/workflows/watch-pangeo-dask-feedstock.yml) 
-
 [![PangeoNotebookUpdater](https://github.com/pangeo-bot/dispatcher/actions/workflows/watch-pangeo-notebook-feedstock.yml/badge.svg)](https://github.com/pangeo-bot/dispatcher/actions/workflows/watch-pangeo-notebook-feedstock.yml)


### PR DESCRIPTION
The GitHub actions workflows for this repo have been temporarily disabled since there's been no activity on this repo for 60 days (xref https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow, https://github.community/t/no-notification-workflow-disabled-after-60-days/182169).

<img width="1552" alt="Screen Shot 2021-07-13 at 12 56 01 PM" src="https://user-images.githubusercontent.com/11656932/125503035-83385dd9-4f14-45ad-b872-7b3a935bf230.png">


This PR makes a small change to the `README` so there will be some type of `git` activity which will (hopefully) cause GHA workflows to be re-enabled. I'm not totally sure who I should ping on this. Maybe @scottyhq?